### PR TITLE
Update 02-cqt-40-preparing-for-query-tuning.adoc

### DIFF
--- a/modules/4.0-cypher-query-tuning/modules/ROOT/pages/02-cqt-40-preparing-for-query-tuning.adoc
+++ b/modules/4.0-cypher-query-tuning/modules/ROOT/pages/02-cqt-40-preparing-for-query-tuning.adoc
@@ -288,13 +288,8 @@ Here are some ways that you can warm up the Page Cache:
 
 [source,Cypher,role=noplay]
 ----
-MATCH (n) RETURN max(id(n))
-MATCH ()-[rel]->() RETURN max(id(rel))
-// or
-CALL apoc.warmup.run() //nodes and relationships
-CALL apoc.warmup.run(true) // include properties
-CALL apoc.warmup.run(true,true) // include large strings and arrays
-CALL apoc.warmup.run(true,true,true) // include indexes
+MATCH (n) RETURN max(id(n));
+MATCH ()-[rel]->() RETURN max(id(rel));
 ----
 
 [NOTE]


### PR DESCRIPTION
A semi colon is necessary at the end of the MATCH commands otherwise the following error is returned 'RETURN can only be used at the end of the query (line 1, column 11 (offset: 10)) "MATCH (n) RETURN max(id(n))"'

Invoking the CALL apoc.warmup.run calls gives the error below in the Broswer Sandbox:
Neo.ClientError.Procedure.ProcedureCallFailed: Failed to invoke procedure `apoc.warmup.run`: Caused by: java.lang.NoSuchMethodError: 'org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer org.neo4j.kernel.api.KernelTransaction.pageCursorTracer()'